### PR TITLE
replace errors with call to generateError

### DIFF
--- a/pkg/otbuiltin/builtin.go
+++ b/pkg/otbuiltin/builtin.go
@@ -3,6 +3,9 @@
 package otbuiltin
 
 import (
+	"errors"
+	"fmt"
+	"runtime"
 	"unsafe"
 
 	glib "github.com/14rcole/ostree-go/pkg/glibobject"
@@ -55,7 +58,7 @@ func openRepo(path string) (*Repo, error) {
 	repo := repoFromNative(crepo)
 	r := glib.GoBool(glib.GBoolean(C.ostree_repo_open(crepo, nil, &cerr)))
 	if !r {
-		return nil, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+		return nil, generateError(cerr)
 	}
 	return repo, nil
 }
@@ -73,8 +76,18 @@ func enableTombstoneCommits(repo *Repo) error {
 	if !tombstoneCommits {
 		C.g_key_file_set_boolean(config, (*C.gchar)(C.CString("core")), (*C.gchar)(C.CString("tombstone-commits")), C.TRUE)
 		if !glib.GoBool(glib.GBoolean(C.ostree_repo_write_config(repo.native(), config, &cerr))) {
-			return glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+			return generateError(cerr)
 		}
 	}
 	return nil
+}
+
+func generateError(err *C.GError) error {
+	goErr := generateError(err)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		return errors.New(fmt.Sprintf("%s:%d - %s", file, line, goErr))
+	} else {
+		return goErr
+	}
 }

--- a/pkg/otbuiltin/checkout.go
+++ b/pkg/otbuiltin/checkout.go
@@ -50,7 +50,7 @@ func Checkout(repoPath, destination, commit string, opts checkoutOptions) error 
 	defer C.g_object_unref(C.gpointer(repoPathc))
 	crepo := C.ostree_repo_new(repoPathc)
 	if !glib.GoBool(glib.GBoolean(C.ostree_repo_open(crepo, (*C.GCancellable)(cancellable.Ptr()), &cerr))) {
-		return glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+		return generateError(cerr)
 	}
 
 	if strings.Compare(checkoutOpts.FromFile, "") != 0 {
@@ -62,7 +62,7 @@ func Checkout(repoPath, destination, commit string, opts checkoutOptions) error 
 		var resolvedCommit *C.char
 		defer C.free(unsafe.Pointer(resolvedCommit))
 		if !glib.GoBool(glib.GBoolean(C.ostree_repo_resolve_rev(crepo, ccommit, C.FALSE, &resolvedCommit, &cerr))) {
-			return glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+			return generateError(cerr)
 		}
 		err := processOneCheckout(crepo, resolvedCommit, checkoutOpts.Subpath, destination, cancellable)
 		if err != nil {
@@ -90,7 +90,7 @@ func processOneCheckout(crepo *C.OstreeRepo, resolvedCommit *C.char, subpath, de
 
 	checkedOut := glib.GoBool(glib.GBoolean(C.ostree_repo_checkout_at(crepo, &repoCheckoutAtOptions, C._at_fdcwd(), cdest, resolvedCommit, nil, &cerr)))
 	if !checkedOut {
-		return glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+		return generateError(cerr)
 	}
 
 	return nil

--- a/pkg/otbuiltin/commit.go
+++ b/pkg/otbuiltin/commit.go
@@ -386,7 +386,7 @@ out:
 	if err != nil {
 		return "", err
 	}
-	return "", glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	return "", generateError(cerr)
 }
 
 // Parse an array of key value pairs of the format KEY=VALUE and add them to a GVariant
@@ -423,7 +423,7 @@ func parseFileByLine(path string, fn handleLineFunc, table *glib.GHashTable, can
 
 	file = glib.ToGFile(unsafe.Pointer(C.g_file_new_for_path(C.CString(path))))
 	if !glib.GoBool(glib.GBoolean(C.g_file_load_contents((*C.GFile)(file.Ptr()), cancellable, &contents, nil, nil, &cerr))) {
-		return glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+		return generateError(cerr)
 	}
 
 	lines = strings.Split(C.GoString(contents), "\n")
@@ -433,7 +433,7 @@ func parseFileByLine(path string, fn handleLineFunc, table *glib.GHashTable, can
 		}
 
 		if err := fn(lines[line], table); err != nil {
-			return glib.ConvertGError(glib.ToGError((unsafe.Pointer(cerr))))
+			return generateError(cerr)
 		}
 	}
 	return nil

--- a/pkg/otbuiltin/init.go
+++ b/pkg/otbuiltin/init.go
@@ -60,17 +60,17 @@ func Init(path string, options initOptions) (bool, error) {
 	  err = errors.New("repository already exists")
 	  return true, err
 	} else if !success {
-	  return false, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+	  return false, generateError(cerr)
 	}*/
 
 	cerr = nil
 	created := glib.GoBool(glib.GBoolean(C.ostree_repo_create(crepo, initOpts.repoMode, nil, &cerr)))
 	if !created {
-		errString := glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr))).Error()
+		errString := generateError(cerr).Error()
 		if strings.Contains(errString, "File exists") {
-			return true, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+			return true, generateError(cerr)
 		}
-		return false, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+		return false, generateError(cerr)
 	}
 	return true, nil
 }

--- a/pkg/otbuiltin/log.go
+++ b/pkg/otbuiltin/log.go
@@ -78,7 +78,7 @@ func Log(repoPath, branch string, options logOptions) ([]LogEntry, error) {
 	}
 
 	if !glib.GoBool(glib.GBoolean(C.ostree_repo_resolve_rev(repo.native(), cbranch, C.FALSE, &checksum, &cerr))) {
-		return nil, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+		return nil, generateError(cerr)
 	}
 
 	return logCommit(repo, checksum, false, flags)
@@ -98,7 +98,7 @@ func logCommit(repo *Repo, checksum *C.char, isRecursive bool, flags OstreeDumpF
 		if isRecursive && glib.GoBool(glib.GBoolean(C.g_error_matches(cerr, C.g_io_error_quark(), C.G_IO_ERROR_NOT_FOUND))) {
 			return nil, nil
 		}
-		return entries, glib.ConvertGError(glib.ToGError(unsafe.Pointer(cerr)))
+		return entries, generateError(cerr)
 	}
 
 	nextLogEntry := dumpLogObject(C.OSTREE_OBJECT_TYPE_COMMIT, checksum, variant, flags)


### PR DESCRIPTION
Previously, errors thrown by any C code were returned by calling a set of nested functions: glib.ConvertGError(glib.ToGError(unsafe.Pointer())).  Not only did this make code difficult to read, but it would only return the error message: no information about the file or the line number where it occured.  This was replaced by the generateError function that, when passed the error, outputs the error string and the exact line of Go code where it was detected.