### PR TITLE
Fix Gobject type error

### DIFF
--- a/pkg/glibobject/gobject.go
+++ b/pkg/glibobject/gobject.go
@@ -66,11 +66,11 @@ func (v *GObject) Unref() {
 }
 
 func (v *GObject) RefSink() {
-	C.g_object_ref_sink(v.native())
+	C.g_object_ref_sink(C.gpointer(v.native()))
 }
 
 func (v *GObject) IsFloating() bool {
-	c := C.g_object_is_floating(v.native())
+	c := C.g_object_is_floating(C.gpointer(v.native()))
 	return GoBool(GBoolean(c))
 }
 


### PR DESCRIPTION
Typecast v.native() to C.gpointer so it can be passed into C.g_object_ref_sink() and C.go_object_is_floating() without error