### PR TITLE
ot/init: cleanup and get rid of global state

### DIFF
--- a/pkg/otbuiltin/builtin.go
+++ b/pkg/otbuiltin/builtin.go
@@ -111,3 +111,9 @@ func generateError(err *C.GError) error {
 	}
 	return goErr
 }
+
+// isOk wraps a return value (gboolean/gint) into a bool.
+// 0 is false/error, everything else is true/ok.
+func isOk(v C.int) bool {
+	return glib.GoBool(glib.GBoolean(v))
+}

--- a/pkg/otbuiltin/init.go
+++ b/pkg/otbuiltin/init.go
@@ -1,11 +1,8 @@
 package otbuiltin
 
 import (
-	"errors"
 	"strings"
 	"unsafe"
-
-	glib "github.com/ostreedev/ostree-go/pkg/glibobject"
 )
 
 // #cgo pkg-config: ostree-1
@@ -15,43 +12,37 @@ import (
 // #include "builtin.go.h"
 import "C"
 
-// Declare variables for options
-var initOpts initOptions
-
-// Contains all of the options for initializing an ostree repo
+// initOptions contains all of the options for initializing an ostree repo
+//
+// Note: while this is private, exported fields are public and part of the API.
 type initOptions struct {
-	Mode string // either bare, archive-z2, or bare-user
-
-	repoMode C.OstreeRepoMode
+	// Mode defines repository mode: either bare, archive-z2, or bare-user
+	Mode string
 }
 
-// Instantiates and returns an initOptions struct with default values set
+// NewInitOptions instantiates and returns an initOptions struct with default values set
 func NewInitOptions() initOptions {
-	io := initOptions{}
-	io.Mode = "bare"
-	io.repoMode = C.OSTREE_REPO_MODE_BARE
-	return io
+	return initOptions{
+		Mode: "bare",
+	}
 }
 
-// Initializes a new ostree repository at the given path.  Returns true
+// Init initializes a new ostree repository at the given path.  Returns true
 // if the repo exists at the location, regardless of whether it was initialized
 // by the function or if it already existed.  Returns an error if the repo could
 // not be initialized
 func Init(path string, options initOptions) (bool, error) {
-	initOpts = options
-	err := parseMode()
+	repoMode, err := parseRepoMode(options.Mode)
 	if err != nil {
 		return false, err
 	}
 
 	// Create a repo struct from the path
-	var cerr *C.GError
-	defer C.free(unsafe.Pointer(cerr))
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
 	pathc := C.g_file_new_for_path(cpath)
 	defer C.g_object_unref(C.gpointer(pathc))
-	crepo := C.ostree_repo_new(pathc)
+	repo := C.ostree_repo_new(pathc)
 
 	// If the repo exists in the filesystem, return an error but set exists to true
 	/* var exists C.gboolean = 0
@@ -63,12 +54,11 @@ func Init(path string, options initOptions) (bool, error) {
 	  return false, generateError(cerr)
 	}*/
 
-	cerr = nil
-	created := glib.GoBool(glib.GBoolean(C.ostree_repo_create(crepo, initOpts.repoMode, nil, &cerr)))
-	if !created {
-		err := generateError(cerr)
-		errString := err.Error()
-		if strings.Contains(errString, "File exists") {
+	var cErr *C.GError
+	defer C.free(unsafe.Pointer(cErr))
+	if r := C.ostree_repo_create(repo, repoMode, nil, &cErr); !isOk(r) {
+		err := generateError(cErr)
+		if strings.Contains(err.Error(), "File exists") {
 			return true, err
 		}
 		return false, err
@@ -76,16 +66,19 @@ func Init(path string, options initOptions) (bool, error) {
 	return true, nil
 }
 
-// Converts the mode string to a C.OSTREE_REPO_MODE enum value
-func parseMode() error {
-	if strings.EqualFold(initOpts.Mode, "bare") {
-		initOpts.repoMode = C.OSTREE_REPO_MODE_BARE
-	} else if strings.EqualFold(initOpts.Mode, "bare-user") {
-		initOpts.repoMode = C.OSTREE_REPO_MODE_BARE_USER
-	} else if strings.EqualFold(initOpts.Mode, "archive-z2") {
-		initOpts.repoMode = C.OSTREE_REPO_MODE_ARCHIVE_Z2
-	} else {
-		return errors.New("Invalid option for mode")
+// parseRepoMode converts a mode string to a C.OSTREE_REPO_MODE enum value
+func parseRepoMode(modeLabel string) (C.OstreeRepoMode, error) {
+	var cErr *C.GError
+	defer C.free(unsafe.Pointer(cErr))
+
+	cModeLabel := C.CString(modeLabel)
+	defer C.free(unsafe.Pointer(cModeLabel))
+
+	var retMode C.OstreeRepoMode
+	if r := C.ostree_repo_mode_from_string(cModeLabel, &retMode, &cErr); !isOk(r) {
+		// NOTE(lucab): zero-value for this C enum has no special/invalid meaning.
+		return C.OSTREE_REPO_MODE_BARE, generateError(cErr)
 	}
-	return nil
+
+	return retMode, nil
 }

--- a/pkg/otbuiltin/init_test.go
+++ b/pkg/otbuiltin/init_test.go
@@ -62,3 +62,36 @@ func TestInitBareUser(t *testing.T) {
 		return
 	}
 }
+
+func TestParseRepoMode(t *testing.T) {
+	tests := []struct {
+		in    string
+		isErr bool
+	}{
+		{
+			"archive-z2",
+			false,
+		},
+		{
+			"bare",
+			false,
+		},
+		{
+			"bare-user",
+			false,
+		},
+		{
+			"fooMode",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		_, err := parseRepoMode(tt.in)
+		if tt.isErr && err == nil {
+			t.Fatal("got unexpected nil error")
+		} else if !tt.isErr && err != nil {
+			t.Fatalf("got unexpected error %q", err)
+		}
+	}
+}


### PR DESCRIPTION
This gets rid of a global mutable variable, and performs a general
minor cleanup of init code. It also adds a minor regression test for
the parsing helper.