### PR TITLE
ot/log: clean and remove unused objects

### DIFF
--- a/pkg/otbuiltin/log_test.go
+++ b/pkg/otbuiltin/log_test.go
@@ -1,7 +1,6 @@
 package otbuiltin
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -14,76 +13,65 @@ func TestLogSuccess(t *testing.T) {
 	// Make a base directory in which all of our test data resides
 	baseDir, err := ioutil.TempDir("", "otbuiltin-test-")
 	if err != nil {
-		t.Errorf("%s", err)
-		return
+		t.Fatalf("%s", err)
 	}
 	defer os.RemoveAll(baseDir)
+
 	// Make a directory in which the repo should exist
 	repoDir := path.Join(baseDir, "repo")
-	err = os.Mkdir(repoDir, 0777)
-	if err != nil {
-		t.Errorf("%s", err)
-		return
+	if err := os.Mkdir(repoDir, 0777); err != nil {
+		t.Fatalf("%s", err)
 	}
 
 	// Initialize the repo
 	inited, err := Init(repoDir, NewInitOptions())
 	if !inited || err != nil {
-		fmt.Println("Cannot test commit: failed to initialize repo")
-		return
+		t.Fatal("Cannot test commit: failed to initialize repo")
 	}
 
-	//Make a new directory full of random data to commit
+	// Make a new directory full of random data to commit
 	commitDir := path.Join(baseDir, "commit1")
-	err = os.Mkdir(commitDir, 0777)
-	if err != nil {
-		t.Errorf("%s", err)
-		return
+	if err := os.Mkdir(commitDir, 0777); err != nil {
+		t.Fatalf("%s", err)
 	}
-	err = gopopulate.PopulateDir(commitDir, "rd", 4, 4)
-	if err != nil {
-		t.Errorf("%s", err)
-		return
+	if err := gopopulate.PopulateDir(commitDir, "rd", 4, 4); err != nil {
+		t.Fatalf("%s", err)
 	}
 
-	//Test commit
+	// Test commit
 	repo, err := OpenRepo(repoDir)
 	if err != nil {
-		t.Errorf("%s", err)
+		t.Fatalf("%s", err)
 	}
 
 	opts := NewCommitOptions()
 	branch := "test-branch"
 	_, err = repo.PrepareTransaction()
 	if err != nil {
-		t.Errorf("%s", err)
+		t.Fatalf("%s", err)
 	}
 
-	ret, err := repo.Commit(commitDir, branch, opts)
-	if err != nil {
-		t.Errorf("%s", err)
-	} else {
-		fmt.Println(ret)
+	if _, err := repo.Commit(commitDir, branch, opts); err != nil {
+		t.Fatalf("%s", err)
 	}
 
-	_, err = repo.CommitTransaction()
-	if err != nil {
-		t.Errorf("%s", err)
+	if _, err = repo.CommitTransaction(); err != nil {
+		t.Fatalf("%s", err)
 	}
 
-	// Add more files to the commit dir and return an updated
-	err = gopopulate.PopulateDir(commitDir, "rd", 4, 4)
-	if err != nil {
-		t.Errorf("%s", err)
-		return
+	// Add more files to the commit dir and return
+	if err := gopopulate.PopulateDir(commitDir, "rd", 4, 4); err != nil {
+		t.Fatalf("%s", err)
 	}
 
 	// Get the logs for the branch
 	logOpts := NewLogOptions()
 	entries, err := Log(repoDir, branch, logOpts)
 	if err != nil {
-		t.Errorf("%s", err)
-		return
+		t.Fatalf("%s", err)
 	}
-	fmt.Printf("%+v\n", entries)
+
+	if len(entries) <= 0 {
+		t.Fatal("got no entries")
+	}
 }


### PR DESCRIPTION
This removes a few unused public items, and performs a general cleanup
of log logic and tests.