### PR TITLE
pkg/otbuiltin: fix build warnings in _g_clear_object

### DIFF
--- a/pkg/otbuiltin/builtin.go.h
+++ b/pkg/otbuiltin/builtin.go.h
@@ -46,7 +46,11 @@ _guint_to_pointer (guint u)
 }
 
 static void
+#ifdef GLIB_VERSION_2_58
+_g_clear_object (GObject **object_ptr)
+#else
 _g_clear_object (volatile GObject **object_ptr)
+#endif
 {
   g_clear_object(object_ptr);
 }


### PR DESCRIPTION
The volatile keyword in _g_clear_object causes lots of warnings like below, starting from glib 2.58 on Fedora 29.

```
In file included from /usr/include/glib-2.0/glib/glist.h:32,
                 from /usr/include/glib-2.0/glib/ghash.h:33,
                 from /usr/include/glib-2.0/glib.h:50,
                 from pkg/otbuiltin/builtin.go:16:
pkg/otbuiltin/builtin.go.h: In function ‘_g_clear_object’:
/usr/include/glib-2.0/glib/gmem.h:121:18: warning: passing argument 1 of
‘g_object_unref’ discards ‘volatile’ qualifier from pointer target type
[-Wdiscarded-qualifiers]
       (destroy) (_ptr);
```

Fixes https://github.com/ostreedev/ostree-go/issues/23