### PR TITLE
builtin.go.h: remove some unused functions

### DIFF
--- a/pkg/otbuiltin/builtin.go.h
+++ b/pkg/otbuiltin/builtin.go.h
@@ -33,22 +33,10 @@ _ostree_repo_file(GFile *file)
   return OSTREE_REPO_FILE (file);
 }
 
-static guint
-_gpointer_to_uint (gpointer ptr)
-{
-  return GPOINTER_TO_UINT (ptr);
-}
-
 static gpointer
 _guint_to_pointer (guint u)
 {
   return GUINT_TO_POINTER (u);
-}
-
-static void
-_g_clear_object (volatile GObject **object_ptr)
-{
-  g_clear_object(object_ptr);
 }
 
 static const GVariantType*


### PR DESCRIPTION
it helps to solve a warning with cgo:

In file included from /usr/include/glib-2.0/glib/glist.h:32,
                 from /usr/include/glib-2.0/glib/ghash.h:33,
                 from /usr/include/glib-2.0/glib.h:50,
                 from vendor/github.com/ostreedev/ostree-go/pkg/otbuiltin/commit.go:16:
vendor/github.com/ostreedev/ostree-go/pkg/otbuiltin/builtin.go.h: In function ‘_g_clear_object’:
/usr/include/glib-2.0/glib/gmem.h:121:18: warning: passing argument 1 of ‘g_object_unref’ discards ‘volatile’ qualifier from pointer target type [-Wdiscarded-qualifiers]
       (destroy) (_ptr);                                                        \
                  ^~~~
/usr/include/glib-2.0/gobject/gobject.h:6

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>