### PR TITLE
builtin: fix an error with golang 1.8

### DIFF
--- a/pkg/otbuiltin/builtin.go
+++ b/pkg/otbuiltin/builtin.go
@@ -112,8 +112,8 @@ func generateError(err *C.GError) error {
 	return goErr
 }
 
-// isOk wraps a return value (gboolean/gint) into a bool.
+// isOk wraps a gboolean return value into a bool.
 // 0 is false/error, everything else is true/ok.
-func isOk(v C.int) bool {
+func isOk(v C.gboolean) bool {
 	return glib.GoBool(glib.GBoolean(v))
 }


### PR DESCRIPTION
Fix this error when using golang 1.8:

ostree-go/pkg/otbuiltin/init.go:59: cannot use r (type C.gboolean) as type C.int in argument to isOk
ostree-go/pkg/otbuiltin/init.go:78: cannot use r (type C.gboolean) as type C.int in argument to isOk

Since the isOk function is used only from init.go, change isOk to
accomodate how it is used.

Reference: https://github.com/containers/storage/pull/247

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>