### PR TITLE
ot/checkout: honor option 'RequireHardlinks'

### DIFF
--- a/pkg/otbuiltin/checkout.go
+++ b/pkg/otbuiltin/checkout.go
@@ -93,6 +93,9 @@ func processOneCheckout(crepo *C.OstreeRepo, resolvedCommit *C.char, destination
 	if opts.Union {
 		repoCheckoutAtOptions.overwrite_mode = C.OSTREE_REPO_CHECKOUT_OVERWRITE_UNION_FILES
 	}
+	if opts.RequireHardlinks {
+		repoCheckoutAtOptions.no_copy_fallback = C.TRUE
+	}
 
 	// Checkout commit to destination
 	if !glib.GoBool(glib.GBoolean(C.ostree_repo_checkout_at(crepo, &repoCheckoutAtOptions, C._at_fdcwd(), cdest, resolvedCommit, nil, &cerr))) {


### PR DESCRIPTION
The option 'RequireHardlinks' was being silently ignored, this commit
adds the code to honor it setting the flag 'no_copy_fallback'.

 Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>

Closes #29 