### PR TITLE
Prevent panic in (*GVariant).Ptr

### DIFF
--- a/pkg/glibobject/gvariant.go
+++ b/pkg/glibobject/gvariant.go
@@ -56,6 +56,9 @@ func (v *GVariant) native() *C.GVariant {
 }
 
 func (v *GVariant) Ptr() unsafe.Pointer {
+	if v == nil {
+		return nil
+	}
 	return v.ptr
 }
 


### PR DESCRIPTION
Handle being called with a nil *GVariant